### PR TITLE
Add CI workflow for Flask app with testing and coverage

### DIFF
--- a/app/workflow/flask.yaml
+++ b/app/workflow/flask.yaml
@@ -1,0 +1,62 @@
+name: Flask App CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # --- Checkout code ---
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # --- Install Python 3.13 ---
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # --- Cache pip for faster CI ---
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # --- Install dependencies ---
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # --- Lint code (flake8) ---
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          flake8 .
+
+      # --- Run pytest ---
+      - name: Run tests
+        run: |
+          pip install pytest
+          pytest
+
+      # --- Run tests with coverage ---
+      - name: Run tests with coverage
+        run: |
+          pip install coverage pytest-cov
+          coverage run -m pytest
+          coverage xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI) of the Flask application. The workflow automates code checkout, environment setup, dependency installation, linting, testing, and test coverage reporting for pushes and pull requests targeting the `main` branch.

Continuous Integration Workflow:

* Added a new workflow configuration file `app/workflow/flask.yaml` to set up CI for the Flask app, triggered on pushes and pull requests to the `main` branch.

Build and Test Automation:

* Configured steps to check out the repository, set up Python 3.13, cache pip dependencies, install project requirements, run linting with flake8, execute tests with pytest, measure test coverage, and upload the coverage report as an artifact.